### PR TITLE
Fix #56: hunk header matching broken in getChangedLines()

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,18 +52,30 @@ Tests use JUnit 5 + Mockito. The `single-module-example` module provides test fi
 
 ## Working with issues
 
-All work is tracked via GitHub Issues and the GitHub Project board (#4). Always:
+All work is tracked via GitHub Issues and the GitHub Project board (#4, project ID `PVT_kwHOAl11PM4Azc-d`). Always:
 
 1. **Work from issues** — every code change should reference an issue
 2. **Use milestones** — issues are grouped into release milestones (1.0.3, 1.0.4, etc.)
 3. **Respect priority labels** — P0-critical, P1-important, P2-minor
 4. **Update the board** — move issues through Status (Backlog → Ready → In progress → In review → Done)
 5. **Branch naming** — use the issue number: `fix/56-hunk-header-matching` or `feature/71-python-port`
+6. **Update status on PR creation** — when a PR is created for an issue, move it to "In review" on the board
 
 When creating new issues, always:
 - Assign a priority label (P0/P1/P2)
 - Assign to the appropriate milestone
 - Add to the project board with Priority, Size, and Start/End dates
+
+### Project board field IDs (for `gh project item-edit`)
+
+- **Status**: `PVTSSF_lAHOAl11PM4Azc-dzgpPguE`
+  - Backlog: `f75ad846`, Ready: `61e4505c`, In progress: `47fc9ee4`, In review: `df73e18b`, Done: `98236657`
+- **Priority**: `PVTSSF_lAHOAl11PM4Azc-dzgpPgzM`
+  - P0: `79628723`, P1: `0a877460`, P2: `da944a9c`
+- **Size**: `PVTSSF_lAHOAl11PM4Azc-dzgpPgzY`
+  - XS: `6c6483d2`, S: `f784b110`, M: `7515a9f1`, L: `817d0097`, XL: `db339eb2`
+- **Start date**: `PVTF_lAHOAl11PM4Azc-dzgpPgzw`
+- **End date**: `PVTF_lAHOAl11PM4Azc-dzgpPgz8`
 
 ## Publishing
 

--- a/core/src/main/java/tech/linebyline/coverage/extension/core/integration/GitInteractor.java
+++ b/core/src/main/java/tech/linebyline/coverage/extension/core/integration/GitInteractor.java
@@ -7,6 +7,7 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -78,48 +79,13 @@ public class GitInteractor {
         // Start the process
         Process process = processBuilder.start();
 
-        HashMap<String, int[]> changedLinesPerFile = new HashMap<>();
+        List<String> diffLines = new ArrayList<>();
 
         // Read the output
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
             String line;
-            boolean passedFirstFileLine = false;
-            boolean passedFirstClassLine = false;
-            ArrayList<Integer> lines = null;
-            int lineIndex = -2;
-            String file = null;
             while ((line = reader.readLine()) != null) {
-
-                if(isLineDiffGitLine(line)){
-                    file = line;
-                    if(passedFirstClassLine){
-                        changedLinesPerFile.put(file, lines.stream().mapToInt(Integer::intValue).toArray());
-                    }
-
-                    passedFirstFileLine = false;
-                    passedFirstClassLine = false;
-                    lines = new ArrayList<>();
-                    lineIndex = -2;
-                }
-
-                if(line.startsWith("@@")){
-                    passedFirstFileLine = true;
-                    lineIndex = -1;
-                }
-
-                if(passedFirstFileLine){
-                    lineIndex++;
-                }
-
-                if(line.contains("class") && !passedFirstClassLine){
-                    passedFirstClassLine = true;
-                }
-
-                if(passedFirstClassLine){
-                    if(line.startsWith("+")){
-                        lines.add(lineIndex);
-                    }
-                }
+                diffLines.add(line);
             }
         }
 
@@ -127,6 +93,62 @@ public class GitInteractor {
         int exitCode = process.waitFor();
         if (exitCode != 0) {
             throw new RuntimeException("Error executing git command: " + exitCode);
+        }
+
+        return parseChangedLines(diffLines);
+    }
+
+    /**
+     * Parses git diff output into a map of file paths to changed line numbers.
+     * @param diffLines the lines of git diff output
+     * @return a map with the file as key and an array of changed lines as value
+     */
+    protected static HashMap<String, int[]> parseChangedLines(List<String> diffLines) {
+        HashMap<String, int[]> changedLinesPerFile = new HashMap<>();
+
+        boolean passedFirstFileLine = false;
+        boolean passedFirstClassLine = false;
+        ArrayList<Integer> lines = null;
+        int lineIndex = -2;
+        String file = null;
+
+        for (String line : diffLines) {
+
+            if(isLineDiffGitLine(line)){
+                if(file != null && passedFirstClassLine){
+                    changedLinesPerFile.put(file, lines.stream().mapToInt(Integer::intValue).toArray());
+                }
+                file = line;
+
+                passedFirstFileLine = false;
+                passedFirstClassLine = false;
+                lines = new ArrayList<>();
+                lineIndex = -2;
+            }
+
+            if(line.startsWith("@@")){
+                passedFirstFileLine = true;
+                lineIndex = -1;
+            }
+
+            if(passedFirstFileLine){
+                lineIndex++;
+            }
+
+            if(line.contains("class") && !passedFirstClassLine){
+                passedFirstClassLine = true;
+            }
+
+            if(passedFirstClassLine){
+                if(line.startsWith("+")){
+                    lines.add(lineIndex);
+                }
+            }
+        }
+
+        // Save the last file (fixes #58: last file was previously dropped)
+        if(file != null && passedFirstClassLine){
+            changedLinesPerFile.put(file, lines.stream().mapToInt(Integer::intValue).toArray());
         }
 
         return changedLinesPerFile;

--- a/core/src/main/java/tech/linebyline/coverage/extension/core/integration/GitInteractor.java
+++ b/core/src/main/java/tech/linebyline/coverage/extension/core/integration/GitInteractor.java
@@ -102,7 +102,7 @@ public class GitInteractor {
                     lineIndex = -2;
                 }
 
-                if(line.startsWith("@@") && line.endsWith("@@")){
+                if(line.startsWith("@@")){
                     passedFirstFileLine = true;
                     lineIndex = -1;
                 }

--- a/core/src/test/java/tech/linebyline/coverage/extension/core/integration/GitInteractorTest.java
+++ b/core/src/test/java/tech/linebyline/coverage/extension/core/integration/GitInteractorTest.java
@@ -5,8 +5,12 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static tech.linebyline.coverage.extension.core.integration.GitInteractor.*;
 
 public class GitInteractorTest {
@@ -52,5 +56,125 @@ public class GitInteractorTest {
         }
     }
 
+    @Test
+    public void parseChangedLines_hunkWithTrailingContext() {
+        // Real-world hunk header: @@ -10,5 +10,7 @@ public class Foo
+        // This was the bug in #56 — endsWith("@@") would not match this
+        List<String> diff = Arrays.asList(
+                "diff --git a/src/main/java/com/example/Foo.java b/src/main/java/com/example/Foo.java",
+                "index abc1234..def5678 100644",
+                "--- a/src/main/java/com/example/Foo.java",
+                "+++ b/src/main/java/com/example/Foo.java",
+                "@@ -10,5 +10,7 @@ public class Foo {",
+                "     int x = 1;",
+                "+    int y = 2;",
+                "+    int z = 3;",
+                "     return x;"
+        );
 
+        HashMap<String, int[]> result = parseChangedLines(diff);
+
+        assertEquals(1, result.size(), "Should contain one file");
+        assertTrue(result.containsKey("diff --git a/src/main/java/com/example/Foo.java b/src/main/java/com/example/Foo.java"));
+        int[] changedLines = result.get("diff --git a/src/main/java/com/example/Foo.java b/src/main/java/com/example/Foo.java");
+        assertEquals(2, changedLines.length, "Should have 2 changed lines");
+    }
+
+    @Test
+    public void parseChangedLines_hunkWithoutTrailingContext() {
+        // Hunk header ending with @@ (no trailing context)
+        List<String> diff = Arrays.asList(
+                "diff --git a/src/main/java/com/example/Bar.java b/src/main/java/com/example/Bar.java",
+                "--- a/src/main/java/com/example/Bar.java",
+                "+++ b/src/main/java/com/example/Bar.java",
+                "@@ -1,3 +1,4 @@",
+                " public class Bar {",
+                "     int x = 1;",
+                "+    int y = 2;",
+                " }"
+        );
+
+        HashMap<String, int[]> result = parseChangedLines(diff);
+
+        assertEquals(1, result.size());
+        int[] changedLines = result.values().iterator().next();
+        assertEquals(1, changedLines.length, "Should have 1 changed line");
+    }
+
+    @Test
+    public void parseChangedLines_multipleFiles() {
+        List<String> diff = Arrays.asList(
+                "diff --git a/src/main/java/com/example/First.java b/src/main/java/com/example/First.java",
+                "--- a/src/main/java/com/example/First.java",
+                "+++ b/src/main/java/com/example/First.java",
+                "@@ -5,3 +5,4 @@ public class First {",
+                "     int a = 1;",
+                "+    int b = 2;",
+                "     return a;",
+                "diff --git a/src/main/java/com/example/Second.java b/src/main/java/com/example/Second.java",
+                "--- a/src/main/java/com/example/Second.java",
+                "+++ b/src/main/java/com/example/Second.java",
+                "@@ -10,2 +10,3 @@ public class Second {",
+                "     String s = \"hello\";",
+                "+    String t = \"world\";",
+                "+    String u = \"!\";",
+                "     return s;"
+        );
+
+        HashMap<String, int[]> result = parseChangedLines(diff);
+
+        assertEquals(2, result.size(), "Should contain two files");
+    }
+
+    @Test
+    public void parseChangedLines_lastFileNotDropped() {
+        // This was the bug in #58 — the last file in a diff was never saved
+        List<String> diff = Arrays.asList(
+                "diff --git a/src/main/java/com/example/Only.java b/src/main/java/com/example/Only.java",
+                "--- a/src/main/java/com/example/Only.java",
+                "+++ b/src/main/java/com/example/Only.java",
+                "@@ -1,4 +1,5 @@ public class Only {",
+                "     int x = 1;",
+                "+    int y = 2;",
+                "     return x;"
+        );
+
+        HashMap<String, int[]> result = parseChangedLines(diff);
+
+        assertEquals(1, result.size(), "Single file should not be dropped");
+        int[] changedLines = result.values().iterator().next();
+        assertEquals(1, changedLines.length);
+    }
+
+    @Test
+    public void parseChangedLines_multipleHunksInOneFile() {
+        List<String> diff = Arrays.asList(
+                "diff --git a/src/main/java/com/example/Multi.java b/src/main/java/com/example/Multi.java",
+                "--- a/src/main/java/com/example/Multi.java",
+                "+++ b/src/main/java/com/example/Multi.java",
+                "@@ -5,3 +5,4 @@ public class Multi {",
+                "     int a = 1;",
+                "+    int b = 2;",
+                "     return a;",
+                "@@ -20,3 +21,4 @@ public class Multi {",
+                "     String s = \"x\";",
+                "+    String t = \"y\";",
+                "     return s;"
+        );
+
+        HashMap<String, int[]> result = parseChangedLines(diff);
+
+        assertEquals(1, result.size(), "Should be one file with two hunks");
+        int[] changedLines = result.values().iterator().next();
+        assertEquals(2, changedLines.length, "Should have 2 changed lines across both hunks");
+    }
+
+    @Test
+    public void parseChangedLines_emptyDiff() {
+        List<String> diff = List.of();
+
+        HashMap<String, int[]> result = parseChangedLines(diff);
+
+        assertTrue(result.isEmpty(), "Empty diff should produce empty result");
+    }
 }


### PR DESCRIPTION
## Summary

- Fixed `@@` hunk header matching — was checking `line.endsWith("@@")` which doesn't match real git hunks like `@@ -10,5 +10,7 @@ public class Foo`
- Extracted `parseChangedLines(List<String>)` as a pure function, separating git I/O from parsing logic
- Also fixes #58: last file in a diff is no longer silently dropped

## Test plan

- [x] 6 new unit tests for `parseChangedLines()` covering:
  - Hunk headers with and without trailing context
  - Multiple files in one diff
  - Multiple hunks in one file
  - Single file not dropped (regression test for #58)
  - Empty diff edge case
- [x] All 9 GitInteractorTest tests pass

Closes #56
Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)