### PR TITLE
Fix #57: parse actual line numbers from hunk headers in getChangedLines()

### DIFF
--- a/core/src/main/java/tech/linebyline/coverage/extension/core/integration/GitInteractor.java
+++ b/core/src/main/java/tech/linebyline/coverage/extension/core/integration/GitInteractor.java
@@ -128,10 +128,14 @@ public class GitInteractor {
 
             if(line.startsWith("@@")){
                 passedFirstFileLine = true;
-                lineIndex = -1;
+                // Parse the actual starting line number from the hunk header (e.g. +15 from "@@ -10,5 +15,7 @@")
+                // Subtract 1 because the first content line after @@ will increment it to the correct value
+                lineIndex = parseHunkStartLine(line) - 1;
             }
 
-            if(passedFirstFileLine){
+            // Only increment for lines that exist in the new file:
+            // skip @@ headers (not code lines) and deleted lines (- prefix, only in old file)
+            if(passedFirstFileLine && !line.startsWith("@@") && !line.startsWith("-")){
                 lineIndex++;
             }
 
@@ -157,6 +161,20 @@ public class GitInteractor {
     private static final String REGEX = "^diff --git a/.* b/.*$";
 
     private static final Pattern PATTERN = Pattern.compile(REGEX);
+
+    private static final Pattern HUNK_PATTERN = Pattern.compile("@@\\s+-\\d+(?:,\\d+)?\\s+\\+(\\d+)(?:,\\d+)?\\s+@@");
+
+    /**
+     * Extracts the new-file starting line number from a hunk header.
+     * E.g. "@@ -10,5 +15,7 @@ public class Foo" returns 15.
+     */
+    protected static int parseHunkStartLine(String line) {
+        Matcher matcher = HUNK_PATTERN.matcher(line);
+        if (matcher.find()) {
+            return Integer.parseInt(matcher.group(1));
+        }
+        throw new IllegalArgumentException("Not a valid hunk header: " + line);
+    }
 
     /**
      * Check if a line is a git diff line in the format of "diff --git a/... b/..."

--- a/core/src/test/java/tech/linebyline/coverage/extension/core/integration/GitInteractorTest.java
+++ b/core/src/test/java/tech/linebyline/coverage/extension/core/integration/GitInteractorTest.java
@@ -57,7 +57,7 @@ public class GitInteractorTest {
     }
 
     @Test
-    public void parseChangedLines_hunkWithTrailingContext() {
+    public void parseChangedLinesHunkWithTrailingContextTest() {
         // Real-world hunk header: @@ -10,5 +10,7 @@ public class Foo
         // This was the bug in #56 — endsWith("@@") would not match this
         List<String> diff = Arrays.asList(
@@ -78,10 +78,11 @@ public class GitInteractorTest {
         assertTrue(result.containsKey("diff --git a/src/main/java/com/example/Foo.java b/src/main/java/com/example/Foo.java"));
         int[] changedLines = result.get("diff --git a/src/main/java/com/example/Foo.java b/src/main/java/com/example/Foo.java");
         assertEquals(2, changedLines.length, "Should have 2 changed lines");
+        assertArrayEquals(new int[]{11, 12}, changedLines, "Lines should be absolute line numbers from hunk header");
     }
 
     @Test
-    public void parseChangedLines_hunkWithoutTrailingContext() {
+    public void parseChangedLinesHunkWithoutTrailingContextTest() {
         // Hunk header ending with @@ (no trailing context)
         List<String> diff = Arrays.asList(
                 "diff --git a/src/main/java/com/example/Bar.java b/src/main/java/com/example/Bar.java",
@@ -99,10 +100,11 @@ public class GitInteractorTest {
         assertEquals(1, result.size());
         int[] changedLines = result.values().iterator().next();
         assertEquals(1, changedLines.length, "Should have 1 changed line");
+        assertArrayEquals(new int[]{3}, changedLines, "Line should be absolute line number");
     }
 
     @Test
-    public void parseChangedLines_multipleFiles() {
+    public void parseChangedLinesMultipleFilesTest() {
         List<String> diff = Arrays.asList(
                 "diff --git a/src/main/java/com/example/First.java b/src/main/java/com/example/First.java",
                 "--- a/src/main/java/com/example/First.java",
@@ -124,10 +126,16 @@ public class GitInteractorTest {
         HashMap<String, int[]> result = parseChangedLines(diff);
 
         assertEquals(2, result.size(), "Should contain two files");
+
+        int[] firstLines = result.get("diff --git a/src/main/java/com/example/First.java b/src/main/java/com/example/First.java");
+        assertArrayEquals(new int[]{6}, firstLines, "First file: +5 start, added line at 6");
+
+        int[] secondLines = result.get("diff --git a/src/main/java/com/example/Second.java b/src/main/java/com/example/Second.java");
+        assertArrayEquals(new int[]{11, 12}, secondLines, "Second file: +10 start, added lines at 11 and 12");
     }
 
     @Test
-    public void parseChangedLines_lastFileNotDropped() {
+    public void parseChangedLinesLastFileNotDroppedTest() {
         // This was the bug in #58 — the last file in a diff was never saved
         List<String> diff = Arrays.asList(
                 "diff --git a/src/main/java/com/example/Only.java b/src/main/java/com/example/Only.java",
@@ -144,10 +152,11 @@ public class GitInteractorTest {
         assertEquals(1, result.size(), "Single file should not be dropped");
         int[] changedLines = result.values().iterator().next();
         assertEquals(1, changedLines.length);
+        assertArrayEquals(new int[]{2}, changedLines);
     }
 
     @Test
-    public void parseChangedLines_multipleHunksInOneFile() {
+    public void parseChangedLinesMultipleHunksInOneFileTest() {
         List<String> diff = Arrays.asList(
                 "diff --git a/src/main/java/com/example/Multi.java b/src/main/java/com/example/Multi.java",
                 "--- a/src/main/java/com/example/Multi.java",
@@ -167,10 +176,42 @@ public class GitInteractorTest {
         assertEquals(1, result.size(), "Should be one file with two hunks");
         int[] changedLines = result.values().iterator().next();
         assertEquals(2, changedLines.length, "Should have 2 changed lines across both hunks");
+        assertArrayEquals(new int[]{6, 22}, changedLines, "Each hunk should use its own absolute start line");
     }
 
     @Test
-    public void parseChangedLines_emptyDiff() {
+    public void parseChangedLinesDeletedLinesDontShiftNumbersTest() {
+        // Deleted lines (- prefix) only exist in the old file and should not increment the line counter
+        List<String> diff = Arrays.asList(
+                "diff --git a/src/main/java/com/example/Del.java b/src/main/java/com/example/Del.java",
+                "--- a/src/main/java/com/example/Del.java",
+                "+++ b/src/main/java/com/example/Del.java",
+                "@@ -5,6 +5,5 @@ public class Del {",
+                "     int a = 1;",
+                "-    int old = 0;",
+                "-    int stale = 0;",
+                "+    int b = 2;",
+                "     return a;"
+        );
+
+        HashMap<String, int[]> result = parseChangedLines(diff);
+
+        assertEquals(1, result.size());
+        int[] changedLines = result.values().iterator().next();
+        // "int a = 1;" is line 5, deleted lines don't count, so "int b = 2;" is line 6
+        assertArrayEquals(new int[]{6}, changedLines, "Deleted lines should not shift line numbers");
+    }
+
+    @Test
+    public void parseHunkStartLineVariousFormatsTest() {
+        assertEquals(15, parseHunkStartLine("@@ -10,5 +15,7 @@"));
+        assertEquals(15, parseHunkStartLine("@@ -10,5 +15,7 @@ public class Foo {"));
+        assertEquals(1, parseHunkStartLine("@@ -1,3 +1,4 @@"));
+        assertEquals(100, parseHunkStartLine("@@ -90 +100 @@"));
+    }
+
+    @Test
+    public void parseChangedLinesEmptyDiffTest() {
         List<String> diff = List.of();
 
         HashMap<String, int[]> result = parseChangedLines(diff);


### PR DESCRIPTION
## Summary

- Parse the actual starting line number from hunk headers (`@@ -old,count +new,count @@`) instead of using a relative counter starting at 0
- Skip deleted lines (`-` prefix) when incrementing the line counter — they only exist in the old file and were incorrectly shifting all subsequent line numbers
- Add `parseHunkStartLine()` helper with regex to extract the `+N` value from hunk headers
- Rename all test methods from `snake_case` to camelCase to match existing conventions

## Context

The line numbers produced by `parseChangedLines()` are passed to JaCoCo's `getLine(lineNumber)`, which expects absolute source file line numbers. Previously, all three bugs in #57 caused mismatches: wrong start position, deleted lines shifting the count, and multiple hunks in one file producing duplicate relative offsets (e.g. both hunks returning index `2` instead of their actual file positions).

## Test plan

- [x] Added `assertArrayEquals` to existing tests to verify actual line number values, not just counts
- [x] New test: `parseChangedLinesDeletedLinesDontShiftNumbersTest` — deleted lines between context/added lines
- [x] New test: `parseHunkStartLineVariousFormatsTest` — with/without trailing context, with/without count
- [x] All 68 core tests pass

Closes #57