### PR TITLE
fix: Last file dropped from getChangedLines() (#58)

### DIFF
--- a/core/src/main/java/tech/linebyline/coverage/extension/core/integration/GitInteractor.java
+++ b/core/src/main/java/tech/linebyline/coverage/extension/core/integration/GitInteractor.java
@@ -121,6 +121,9 @@ public class GitInteractor {
                     }
                 }
             }
+            if (file != null && lines != null) {
+                changedLinesPerFile.put(file, lines.stream().mapToInt(Integer::intValue).toArray());
+            }
         }
 
         // Wait for the process to complete


### PR DESCRIPTION
Fixes #58

## What was done

Fix applied and committed. Here's what was done:

**Root cause:** In `GitInteractor.java` (line 91–123), the while loop stores each file's changed lines only when the *next* `diff --git` header is encountered. The last file in the diff has no subsequent header to trigger that storage, so its lines were silently dropped.

**Fix:** Added after the while loop (inside the try-with-resources block):
```java
if (file != null && lines != null) {
    changedLinesPerFile.put(file, lines.stream().mapToInt(Integer::intValue).toArray());
}
```

This ensures the final file's accumulated changed lines are stored in the map before the reader closes.

---
*Automated by Night Worker*