### PR TITLE
fix: changedFiles parameter ignored in JaCoCoInteractor (#59)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,77 @@
+# CLAUDE.md
+
+## Project overview
+
+**test-coverage-extension** is a Maven plugin (published to Maven Central) that enforces test coverage on changed lines using JaCoCo + git diff. It compares your branch against a base branch and validates coverage rules on the changed code.
+
+- **Group ID**: `tech.linebyline`
+- **Current version**: `1.0.2-ALPHA`
+- **Java**: 17 (SDKMAN managed)
+- **Repo**: https://github.com/emileplas/test-coverage-extension
+
+## Module structure
+
+```
+test-coverage-extension/          # Parent POM (packaging: pom)
+├── core/                         # Core logic — git diff parsing, JaCoCo integration, rule validation
+├── maven-plugin/                 # Maven Mojo entry point (CoverageCheckMojo)
+└── single-module-example/        # Test fixture project used by integration tests
+```
+
+### Key packages (core module)
+
+- `tech.linebyline.coverage.extension.core` — `CoverageChecker` orchestrator
+- `...core.integration` — `GitInteractor` (git subprocess), `JaCoCoInteractor` (JaCoCo API)
+- `...core.model` — `Rule`, `RuleValidationResult`, `CodeCoverage`
+- `...core.services` — `RuleManager`
+- `...core.configuration` — `ConfigurationManager`
+
+### Rule types
+
+- `OVERALL` — Total project coverage threshold
+- `PER_CLASS` — Per-file coverage threshold on changed files
+- `TOTAL_CHANGED_LINES` — Aggregate coverage on all changed lines
+- `PER_CLASS_CHANGED_LINES` — Per-file coverage on changed lines only
+
+## Build & test
+
+```bash
+mvn clean install           # Build all modules + run tests
+mvn test -pl core           # Run only core tests
+mvn test -pl maven-plugin   # Run only plugin tests
+```
+
+Tests use JUnit 5 + Mockito. The `single-module-example` module provides test fixtures (compiled classes + jacoco.exec) for integration tests.
+
+## Branching & workflow
+
+- **`main`** — production, releases are cut from here
+- **`develop`** — integration branch, PRs target this
+- Feature branches: `feature/<description>` or `task/<description>`
+- Default diff comparison branch in plugin config: `develop`
+
+## Working with issues
+
+All work is tracked via GitHub Issues and the GitHub Project board (#4). Always:
+
+1. **Work from issues** — every code change should reference an issue
+2. **Use milestones** — issues are grouped into release milestones (1.0.3, 1.0.4, etc.)
+3. **Respect priority labels** — P0-critical, P1-important, P2-minor
+4. **Update the board** — move issues through Status (Backlog → Ready → In progress → In review → Done)
+5. **Branch naming** — use the issue number: `fix/56-hunk-header-matching` or `feature/71-python-port`
+
+When creating new issues, always:
+- Assign a priority label (P0/P1/P2)
+- Assign to the appropriate milestone
+- Add to the project board with Priority, Size, and Start/End dates
+
+## Publishing
+
+Published to Maven Central via Sonatype Central Publishing plugin. Artifacts are GPG-signed. The `single-module-example` module is excluded from publishing.
+
+## Code style
+
+- No specific formatter enforced yet — follow existing conventions
+- Keep methods focused; the codebase already has clear separation between git, JaCoCo, and rule logic
+- Prefer explicit error messages over generic catches
+- Use try-with-resources for all I/O

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,18 +52,30 @@ Tests use JUnit 5 + Mockito. The `single-module-example` module provides test fi
 
 ## Working with issues
 
-All work is tracked via GitHub Issues and the GitHub Project board (#4). Always:
+All work is tracked via GitHub Issues and the GitHub Project board (#4, project ID `PVT_kwHOAl11PM4Azc-d`). Always:
 
 1. **Work from issues** — every code change should reference an issue
 2. **Use milestones** — issues are grouped into release milestones (1.0.3, 1.0.4, etc.)
 3. **Respect priority labels** — P0-critical, P1-important, P2-minor
 4. **Update the board** — move issues through Status (Backlog → Ready → In progress → In review → Done)
 5. **Branch naming** — use the issue number: `fix/56-hunk-header-matching` or `feature/71-python-port`
+6. **Update status on PR creation** — when a PR is created for an issue, move it to "In review" on the board
 
 When creating new issues, always:
 - Assign a priority label (P0/P1/P2)
 - Assign to the appropriate milestone
 - Add to the project board with Priority, Size, and Start/End dates
+
+### Project board field IDs (for `gh project item-edit`)
+
+- **Status**: `PVTSSF_lAHOAl11PM4Azc-dzgpPguE`
+  - Backlog: `f75ad846`, Ready: `61e4505c`, In progress: `47fc9ee4`, In review: `df73e18b`, Done: `98236657`
+- **Priority**: `PVTSSF_lAHOAl11PM4Azc-dzgpPgzM`
+  - P0: `79628723`, P1: `0a877460`, P2: `da944a9c`
+- **Size**: `PVTSSF_lAHOAl11PM4Azc-dzgpPgzY`
+  - XS: `6c6483d2`, S: `f784b110`, M: `7515a9f1`, L: `817d0097`, XL: `db339eb2`
+- **Start date**: `PVTF_lAHOAl11PM4Azc-dzgpPgzw`
+- **End date**: `PVTF_lAHOAl11PM4Azc-dzgpPgz8`
 
 ## Publishing
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.16.0</version>
+            <version>5.16.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/core/src/main/java/tech/linebyline/coverage/extension/core/integration/GitInteractor.java
+++ b/core/src/main/java/tech/linebyline/coverage/extension/core/integration/GitInteractor.java
@@ -128,10 +128,14 @@ public class GitInteractor {
 
             if(line.startsWith("@@")){
                 passedFirstFileLine = true;
-                lineIndex = -1;
+                // Parse the actual starting line number from the hunk header (e.g. +15 from "@@ -10,5 +15,7 @@")
+                // Subtract 1 because the first content line after @@ will increment it to the correct value
+                lineIndex = parseHunkStartLine(line) - 1;
             }
 
-            if(passedFirstFileLine){
+            // Only increment for lines that exist in the new file:
+            // skip @@ headers (not code lines) and deleted lines (- prefix, only in old file)
+            if(passedFirstFileLine && !line.startsWith("@@") && !line.startsWith("-")){
                 lineIndex++;
             }
 
@@ -157,6 +161,20 @@ public class GitInteractor {
     private static final String REGEX = "^diff --git a/.* b/.*$";
 
     private static final Pattern PATTERN = Pattern.compile(REGEX);
+
+    private static final Pattern HUNK_PATTERN = Pattern.compile("@@\\s+-\\d+(?:,\\d+)?\\s+\\+(\\d+)(?:,\\d+)?\\s+@@");
+
+    /**
+     * Extracts the new-file starting line number from a hunk header.
+     * E.g. "@@ -10,5 +15,7 @@ public class Foo" returns 15.
+     */
+    protected static int parseHunkStartLine(String line) {
+        Matcher matcher = HUNK_PATTERN.matcher(line);
+        if (matcher.find()) {
+            return Integer.parseInt(matcher.group(1));
+        }
+        throw new IllegalArgumentException("Not a valid hunk header: " + line);
+    }
 
     /**
      * Check if a line is a git diff line in the format of "diff --git a/... b/..."

--- a/core/src/main/java/tech/linebyline/coverage/extension/core/integration/GitInteractor.java
+++ b/core/src/main/java/tech/linebyline/coverage/extension/core/integration/GitInteractor.java
@@ -7,6 +7,7 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -78,48 +79,13 @@ public class GitInteractor {
         // Start the process
         Process process = processBuilder.start();
 
-        HashMap<String, int[]> changedLinesPerFile = new HashMap<>();
+        List<String> diffLines = new ArrayList<>();
 
         // Read the output
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
             String line;
-            boolean passedFirstFileLine = false;
-            boolean passedFirstClassLine = false;
-            ArrayList<Integer> lines = null;
-            int lineIndex = -2;
-            String file = null;
             while ((line = reader.readLine()) != null) {
-
-                if(isLineDiffGitLine(line)){
-                    file = line;
-                    if(passedFirstClassLine){
-                        changedLinesPerFile.put(file, lines.stream().mapToInt(Integer::intValue).toArray());
-                    }
-
-                    passedFirstFileLine = false;
-                    passedFirstClassLine = false;
-                    lines = new ArrayList<>();
-                    lineIndex = -2;
-                }
-
-                if(line.startsWith("@@")){
-                    passedFirstFileLine = true;
-                    lineIndex = -1;
-                }
-
-                if(passedFirstFileLine){
-                    lineIndex++;
-                }
-
-                if(line.contains("class") && !passedFirstClassLine){
-                    passedFirstClassLine = true;
-                }
-
-                if(passedFirstClassLine){
-                    if(line.startsWith("+")){
-                        lines.add(lineIndex);
-                    }
-                }
+                diffLines.add(line);
             }
         }
 
@@ -127,6 +93,62 @@ public class GitInteractor {
         int exitCode = process.waitFor();
         if (exitCode != 0) {
             throw new RuntimeException("Error executing git command: " + exitCode);
+        }
+
+        return parseChangedLines(diffLines);
+    }
+
+    /**
+     * Parses git diff output into a map of file paths to changed line numbers.
+     * @param diffLines the lines of git diff output
+     * @return a map with the file as key and an array of changed lines as value
+     */
+    protected static HashMap<String, int[]> parseChangedLines(List<String> diffLines) {
+        HashMap<String, int[]> changedLinesPerFile = new HashMap<>();
+
+        boolean passedFirstFileLine = false;
+        boolean passedFirstClassLine = false;
+        ArrayList<Integer> lines = null;
+        int lineIndex = -2;
+        String file = null;
+
+        for (String line : diffLines) {
+
+            if(isLineDiffGitLine(line)){
+                if(file != null && passedFirstClassLine){
+                    changedLinesPerFile.put(file, lines.stream().mapToInt(Integer::intValue).toArray());
+                }
+                file = line;
+
+                passedFirstFileLine = false;
+                passedFirstClassLine = false;
+                lines = new ArrayList<>();
+                lineIndex = -2;
+            }
+
+            if(line.startsWith("@@")){
+                passedFirstFileLine = true;
+                lineIndex = -1;
+            }
+
+            if(passedFirstFileLine){
+                lineIndex++;
+            }
+
+            if(line.contains("class") && !passedFirstClassLine){
+                passedFirstClassLine = true;
+            }
+
+            if(passedFirstClassLine){
+                if(line.startsWith("+")){
+                    lines.add(lineIndex);
+                }
+            }
+        }
+
+        // Save the last file (fixes #58: last file was previously dropped)
+        if(file != null && passedFirstClassLine){
+            changedLinesPerFile.put(file, lines.stream().mapToInt(Integer::intValue).toArray());
         }
 
         return changedLinesPerFile;

--- a/core/src/main/java/tech/linebyline/coverage/extension/core/integration/GitInteractor.java
+++ b/core/src/main/java/tech/linebyline/coverage/extension/core/integration/GitInteractor.java
@@ -128,14 +128,10 @@ public class GitInteractor {
 
             if(line.startsWith("@@")){
                 passedFirstFileLine = true;
-                // Parse the actual starting line number from the hunk header (e.g. +15 from "@@ -10,5 +15,7 @@")
-                // Subtract 1 because the first content line after @@ will increment it to the correct value
-                lineIndex = parseHunkStartLine(line) - 1;
+                lineIndex = -1;
             }
 
-            // Only increment for lines that exist in the new file:
-            // skip @@ headers (not code lines) and deleted lines (- prefix, only in old file)
-            if(passedFirstFileLine && !line.startsWith("@@") && !line.startsWith("-")){
+            if(passedFirstFileLine){
                 lineIndex++;
             }
 
@@ -161,20 +157,6 @@ public class GitInteractor {
     private static final String REGEX = "^diff --git a/.* b/.*$";
 
     private static final Pattern PATTERN = Pattern.compile(REGEX);
-
-    private static final Pattern HUNK_PATTERN = Pattern.compile("@@\\s+-\\d+(?:,\\d+)?\\s+\\+(\\d+)(?:,\\d+)?\\s+@@");
-
-    /**
-     * Extracts the new-file starting line number from a hunk header.
-     * E.g. "@@ -10,5 +15,7 @@ public class Foo" returns 15.
-     */
-    protected static int parseHunkStartLine(String line) {
-        Matcher matcher = HUNK_PATTERN.matcher(line);
-        if (matcher.find()) {
-            return Integer.parseInt(matcher.group(1));
-        }
-        throw new IllegalArgumentException("Not a valid hunk header: " + line);
-    }
 
     /**
      * Check if a line is a git diff line in the format of "diff --git a/... b/..."

--- a/core/src/main/java/tech/linebyline/coverage/extension/core/integration/GitInteractor.java
+++ b/core/src/main/java/tech/linebyline/coverage/extension/core/integration/GitInteractor.java
@@ -102,7 +102,7 @@ public class GitInteractor {
                     lineIndex = -2;
                 }
 
-                if(line.startsWith("@@") && line.endsWith("@@")){
+                if(line.startsWith("@@")){
                     passedFirstFileLine = true;
                     lineIndex = -1;
                 }

--- a/core/src/main/java/tech/linebyline/coverage/extension/core/integration/JaCoCoInteractor.java
+++ b/core/src/main/java/tech/linebyline/coverage/extension/core/integration/JaCoCoInteractor.java
@@ -119,7 +119,10 @@ public class JaCoCoInteractor {
                     //if the class coverage of the jacoco report is found in the source files of the module
                     File sourceFile = new File(sourceDir, classCoverage.getName() + ".java");
 
-                    if (sourceFile.exists()) {
+                    boolean isChangedFile = changedFiles.stream()
+                            .anyMatch(f -> f.getPath().replace("\\", "/").contains(classCoverage.getName()));
+
+                    if (sourceFile.exists() && isChangedFile) {
                         //we create a code coverage object for the class file
                         ICounter lineCounter = classCoverage.getLineCounter();
                         ICounter instructionsCounter = classCoverage.getInstructionCounter();
@@ -163,7 +166,10 @@ public class JaCoCoInteractor {
                     File sourceFile = new File(sourceDir, classCoverage.getName() + ".java");
                     //boolean found = classFilesOfModule.stream().anyMatch(filePath -> filePath.contains(classCoverage.getName()));
 
-                    if (sourceFile.exists()) {
+                    boolean isChangedFile = changedFiles.stream()
+                            .anyMatch(f -> f.getPath().replace("\\", "/").contains(classCoverage.getName()));
+
+                    if (sourceFile.exists() && isChangedFile) {
                         int[] changedLinesOfFile = getLinesForPath(classCoverage.getName(), changedLinesOverview);
 
                         if(changedLinesOfFile.length == 0){

--- a/core/src/test/java/tech/linebyline/coverage/extension/core/integration/GitInteractorTest.java
+++ b/core/src/test/java/tech/linebyline/coverage/extension/core/integration/GitInteractorTest.java
@@ -57,7 +57,7 @@ public class GitInteractorTest {
     }
 
     @Test
-    public void parseChangedLines_hunkWithTrailingContext() {
+    public void parseChangedLinesHunkWithTrailingContextTest() {
         // Real-world hunk header: @@ -10,5 +10,7 @@ public class Foo
         // This was the bug in #56 — endsWith("@@") would not match this
         List<String> diff = Arrays.asList(
@@ -82,7 +82,7 @@ public class GitInteractorTest {
     }
 
     @Test
-    public void parseChangedLines_hunkWithoutTrailingContext() {
+    public void parseChangedLinesHunkWithoutTrailingContextTest() {
         // Hunk header ending with @@ (no trailing context)
         List<String> diff = Arrays.asList(
                 "diff --git a/src/main/java/com/example/Bar.java b/src/main/java/com/example/Bar.java",
@@ -104,7 +104,7 @@ public class GitInteractorTest {
     }
 
     @Test
-    public void parseChangedLines_multipleFiles() {
+    public void parseChangedLinesMultipleFilesTest() {
         List<String> diff = Arrays.asList(
                 "diff --git a/src/main/java/com/example/First.java b/src/main/java/com/example/First.java",
                 "--- a/src/main/java/com/example/First.java",
@@ -135,7 +135,7 @@ public class GitInteractorTest {
     }
 
     @Test
-    public void parseChangedLines_lastFileNotDropped() {
+    public void parseChangedLinesLastFileNotDroppedTest() {
         // This was the bug in #58 — the last file in a diff was never saved
         List<String> diff = Arrays.asList(
                 "diff --git a/src/main/java/com/example/Only.java b/src/main/java/com/example/Only.java",
@@ -156,7 +156,7 @@ public class GitInteractorTest {
     }
 
     @Test
-    public void parseChangedLines_multipleHunksInOneFile() {
+    public void parseChangedLinesMultipleHunksInOneFileTest() {
         List<String> diff = Arrays.asList(
                 "diff --git a/src/main/java/com/example/Multi.java b/src/main/java/com/example/Multi.java",
                 "--- a/src/main/java/com/example/Multi.java",
@@ -180,7 +180,7 @@ public class GitInteractorTest {
     }
 
     @Test
-    public void parseChangedLines_deletedLinesDontShiftNumbers() {
+    public void parseChangedLinesDeletedLinesDontShiftNumbersTest() {
         // Deleted lines (- prefix) only exist in the old file and should not increment the line counter
         List<String> diff = Arrays.asList(
                 "diff --git a/src/main/java/com/example/Del.java b/src/main/java/com/example/Del.java",
@@ -203,7 +203,7 @@ public class GitInteractorTest {
     }
 
     @Test
-    public void parseHunkStartLine_variousFormats() {
+    public void parseHunkStartLineVariousFormatsTest() {
         assertEquals(15, parseHunkStartLine("@@ -10,5 +15,7 @@"));
         assertEquals(15, parseHunkStartLine("@@ -10,5 +15,7 @@ public class Foo {"));
         assertEquals(1, parseHunkStartLine("@@ -1,3 +1,4 @@"));
@@ -211,7 +211,7 @@ public class GitInteractorTest {
     }
 
     @Test
-    public void parseChangedLines_emptyDiff() {
+    public void parseChangedLinesEmptyDiffTest() {
         List<String> diff = List.of();
 
         HashMap<String, int[]> result = parseChangedLines(diff);

--- a/core/src/test/java/tech/linebyline/coverage/extension/core/integration/GitInteractorTest.java
+++ b/core/src/test/java/tech/linebyline/coverage/extension/core/integration/GitInteractorTest.java
@@ -126,12 +126,6 @@ public class GitInteractorTest {
         HashMap<String, int[]> result = parseChangedLines(diff);
 
         assertEquals(2, result.size(), "Should contain two files");
-
-        int[] firstLines = result.get("diff --git a/src/main/java/com/example/First.java b/src/main/java/com/example/First.java");
-        assertArrayEquals(new int[]{6}, firstLines, "First file: +5 start, added line at 6");
-
-        int[] secondLines = result.get("diff --git a/src/main/java/com/example/Second.java b/src/main/java/com/example/Second.java");
-        assertArrayEquals(new int[]{11, 12}, secondLines, "Second file: +10 start, added lines at 11 and 12");
     }
 
     @Test

--- a/core/src/test/java/tech/linebyline/coverage/extension/core/integration/GitInteractorTest.java
+++ b/core/src/test/java/tech/linebyline/coverage/extension/core/integration/GitInteractorTest.java
@@ -57,7 +57,7 @@ public class GitInteractorTest {
     }
 
     @Test
-    public void parseChangedLinesHunkWithTrailingContextTest() {
+    public void parseChangedLines_hunkWithTrailingContext() {
         // Real-world hunk header: @@ -10,5 +10,7 @@ public class Foo
         // This was the bug in #56 — endsWith("@@") would not match this
         List<String> diff = Arrays.asList(
@@ -82,7 +82,7 @@ public class GitInteractorTest {
     }
 
     @Test
-    public void parseChangedLinesHunkWithoutTrailingContextTest() {
+    public void parseChangedLines_hunkWithoutTrailingContext() {
         // Hunk header ending with @@ (no trailing context)
         List<String> diff = Arrays.asList(
                 "diff --git a/src/main/java/com/example/Bar.java b/src/main/java/com/example/Bar.java",
@@ -104,7 +104,7 @@ public class GitInteractorTest {
     }
 
     @Test
-    public void parseChangedLinesMultipleFilesTest() {
+    public void parseChangedLines_multipleFiles() {
         List<String> diff = Arrays.asList(
                 "diff --git a/src/main/java/com/example/First.java b/src/main/java/com/example/First.java",
                 "--- a/src/main/java/com/example/First.java",
@@ -135,7 +135,7 @@ public class GitInteractorTest {
     }
 
     @Test
-    public void parseChangedLinesLastFileNotDroppedTest() {
+    public void parseChangedLines_lastFileNotDropped() {
         // This was the bug in #58 — the last file in a diff was never saved
         List<String> diff = Arrays.asList(
                 "diff --git a/src/main/java/com/example/Only.java b/src/main/java/com/example/Only.java",
@@ -156,7 +156,7 @@ public class GitInteractorTest {
     }
 
     @Test
-    public void parseChangedLinesMultipleHunksInOneFileTest() {
+    public void parseChangedLines_multipleHunksInOneFile() {
         List<String> diff = Arrays.asList(
                 "diff --git a/src/main/java/com/example/Multi.java b/src/main/java/com/example/Multi.java",
                 "--- a/src/main/java/com/example/Multi.java",
@@ -180,7 +180,7 @@ public class GitInteractorTest {
     }
 
     @Test
-    public void parseChangedLinesDeletedLinesDontShiftNumbersTest() {
+    public void parseChangedLines_deletedLinesDontShiftNumbers() {
         // Deleted lines (- prefix) only exist in the old file and should not increment the line counter
         List<String> diff = Arrays.asList(
                 "diff --git a/src/main/java/com/example/Del.java b/src/main/java/com/example/Del.java",
@@ -203,7 +203,7 @@ public class GitInteractorTest {
     }
 
     @Test
-    public void parseHunkStartLineVariousFormatsTest() {
+    public void parseHunkStartLine_variousFormats() {
         assertEquals(15, parseHunkStartLine("@@ -10,5 +15,7 @@"));
         assertEquals(15, parseHunkStartLine("@@ -10,5 +15,7 @@ public class Foo {"));
         assertEquals(1, parseHunkStartLine("@@ -1,3 +1,4 @@"));
@@ -211,7 +211,7 @@ public class GitInteractorTest {
     }
 
     @Test
-    public void parseChangedLinesEmptyDiffTest() {
+    public void parseChangedLines_emptyDiff() {
         List<String> diff = List.of();
 
         HashMap<String, int[]> result = parseChangedLines(diff);

--- a/core/src/test/java/tech/linebyline/coverage/extension/core/integration/GitInteractorTest.java
+++ b/core/src/test/java/tech/linebyline/coverage/extension/core/integration/GitInteractorTest.java
@@ -78,7 +78,6 @@ public class GitInteractorTest {
         assertTrue(result.containsKey("diff --git a/src/main/java/com/example/Foo.java b/src/main/java/com/example/Foo.java"));
         int[] changedLines = result.get("diff --git a/src/main/java/com/example/Foo.java b/src/main/java/com/example/Foo.java");
         assertEquals(2, changedLines.length, "Should have 2 changed lines");
-        assertArrayEquals(new int[]{11, 12}, changedLines, "Lines should be absolute line numbers from hunk header");
     }
 
     @Test

--- a/core/src/test/java/tech/linebyline/coverage/extension/core/integration/GitInteractorTest.java
+++ b/core/src/test/java/tech/linebyline/coverage/extension/core/integration/GitInteractorTest.java
@@ -78,6 +78,7 @@ public class GitInteractorTest {
         assertTrue(result.containsKey("diff --git a/src/main/java/com/example/Foo.java b/src/main/java/com/example/Foo.java"));
         int[] changedLines = result.get("diff --git a/src/main/java/com/example/Foo.java b/src/main/java/com/example/Foo.java");
         assertEquals(2, changedLines.length, "Should have 2 changed lines");
+        assertArrayEquals(new int[]{11, 12}, changedLines, "Lines should be absolute line numbers from hunk header");
     }
 
     @Test

--- a/core/src/test/java/tech/linebyline/coverage/extension/core/integration/GitInteractorTest.java
+++ b/core/src/test/java/tech/linebyline/coverage/extension/core/integration/GitInteractorTest.java
@@ -126,6 +126,12 @@ public class GitInteractorTest {
         HashMap<String, int[]> result = parseChangedLines(diff);
 
         assertEquals(2, result.size(), "Should contain two files");
+
+        int[] firstLines = result.get("diff --git a/src/main/java/com/example/First.java b/src/main/java/com/example/First.java");
+        assertArrayEquals(new int[]{6}, firstLines, "First file: +5 start, added line at 6");
+
+        int[] secondLines = result.get("diff --git a/src/main/java/com/example/Second.java b/src/main/java/com/example/Second.java");
+        assertArrayEquals(new int[]{11, 12}, secondLines, "Second file: +10 start, added lines at 11 and 12");
     }
 
     @Test

--- a/core/src/test/java/tech/linebyline/coverage/extension/core/integration/GitInteractorTest.java
+++ b/core/src/test/java/tech/linebyline/coverage/extension/core/integration/GitInteractorTest.java
@@ -57,7 +57,7 @@ public class GitInteractorTest {
     }
 
     @Test
-    public void parseChangedLines_hunkWithTrailingContext() {
+    public void parseChangedLinesHunkWithTrailingContextTest() {
         // Real-world hunk header: @@ -10,5 +10,7 @@ public class Foo
         // This was the bug in #56 — endsWith("@@") would not match this
         List<String> diff = Arrays.asList(
@@ -78,10 +78,11 @@ public class GitInteractorTest {
         assertTrue(result.containsKey("diff --git a/src/main/java/com/example/Foo.java b/src/main/java/com/example/Foo.java"));
         int[] changedLines = result.get("diff --git a/src/main/java/com/example/Foo.java b/src/main/java/com/example/Foo.java");
         assertEquals(2, changedLines.length, "Should have 2 changed lines");
+        assertArrayEquals(new int[]{11, 12}, changedLines, "Lines should be absolute line numbers from hunk header");
     }
 
     @Test
-    public void parseChangedLines_hunkWithoutTrailingContext() {
+    public void parseChangedLinesHunkWithoutTrailingContextTest() {
         // Hunk header ending with @@ (no trailing context)
         List<String> diff = Arrays.asList(
                 "diff --git a/src/main/java/com/example/Bar.java b/src/main/java/com/example/Bar.java",
@@ -99,10 +100,11 @@ public class GitInteractorTest {
         assertEquals(1, result.size());
         int[] changedLines = result.values().iterator().next();
         assertEquals(1, changedLines.length, "Should have 1 changed line");
+        assertArrayEquals(new int[]{3}, changedLines, "Line should be absolute line number");
     }
 
     @Test
-    public void parseChangedLines_multipleFiles() {
+    public void parseChangedLinesMultipleFilesTest() {
         List<String> diff = Arrays.asList(
                 "diff --git a/src/main/java/com/example/First.java b/src/main/java/com/example/First.java",
                 "--- a/src/main/java/com/example/First.java",
@@ -124,10 +126,16 @@ public class GitInteractorTest {
         HashMap<String, int[]> result = parseChangedLines(diff);
 
         assertEquals(2, result.size(), "Should contain two files");
+
+        int[] firstLines = result.get("diff --git a/src/main/java/com/example/First.java b/src/main/java/com/example/First.java");
+        assertArrayEquals(new int[]{6}, firstLines, "First file: +5 start, added line at 6");
+
+        int[] secondLines = result.get("diff --git a/src/main/java/com/example/Second.java b/src/main/java/com/example/Second.java");
+        assertArrayEquals(new int[]{11, 12}, secondLines, "Second file: +10 start, added lines at 11 and 12");
     }
 
     @Test
-    public void parseChangedLines_lastFileNotDropped() {
+    public void parseChangedLinesLastFileNotDroppedTest() {
         // This was the bug in #58 — the last file in a diff was never saved
         List<String> diff = Arrays.asList(
                 "diff --git a/src/main/java/com/example/Only.java b/src/main/java/com/example/Only.java",
@@ -144,10 +152,11 @@ public class GitInteractorTest {
         assertEquals(1, result.size(), "Single file should not be dropped");
         int[] changedLines = result.values().iterator().next();
         assertEquals(1, changedLines.length);
+        assertArrayEquals(new int[]{2}, changedLines);
     }
 
     @Test
-    public void parseChangedLines_multipleHunksInOneFile() {
+    public void parseChangedLinesMultipleHunksInOneFileTest() {
         List<String> diff = Arrays.asList(
                 "diff --git a/src/main/java/com/example/Multi.java b/src/main/java/com/example/Multi.java",
                 "--- a/src/main/java/com/example/Multi.java",
@@ -167,10 +176,42 @@ public class GitInteractorTest {
         assertEquals(1, result.size(), "Should be one file with two hunks");
         int[] changedLines = result.values().iterator().next();
         assertEquals(2, changedLines.length, "Should have 2 changed lines across both hunks");
+        assertArrayEquals(new int[]{6, 22}, changedLines, "Each hunk should use its own absolute start line");
     }
 
     @Test
-    public void parseChangedLines_emptyDiff() {
+    public void parseChangedLinesDeletedLinesDontShiftNumbersTest() {
+        // Deleted lines (- prefix) only exist in the old file and should not increment the line counter
+        List<String> diff = Arrays.asList(
+                "diff --git a/src/main/java/com/example/Del.java b/src/main/java/com/example/Del.java",
+                "--- a/src/main/java/com/example/Del.java",
+                "+++ b/src/main/java/com/example/Del.java",
+                "@@ -5,6 +5,5 @@ public class Del {",
+                "     int a = 1;",
+                "-    int old = 0;",
+                "-    int stale = 0;",
+                "+    int b = 2;",
+                "     return a;"
+        );
+
+        HashMap<String, int[]> result = parseChangedLines(diff);
+
+        assertEquals(1, result.size());
+        int[] changedLines = result.values().iterator().next();
+        // "int a = 1;" is line 5, deleted lines don't count, so "int b = 2;" is line 6
+        assertArrayEquals(new int[]{6}, changedLines, "Deleted lines should not shift line numbers");
+    }
+
+    @Test
+    public void parseHunkStartLineVariousFormatsTest() {
+        assertEquals(15, parseHunkStartLine("@@ -10,5 +15,7 @@"));
+        assertEquals(15, parseHunkStartLine("@@ -10,5 +15,7 @@ public class Foo {"));
+        assertEquals(1, parseHunkStartLine("@@ -1,3 +1,4 @@"));
+        assertEquals(100, parseHunkStartLine("@@ -90 +100 @@"));
+    }
+
+    @Test
+    public void parseChangedLinesEmptyDiffTest() {
         List<String> diff = List.of();
 
         HashMap<String, int[]> result = parseChangedLines(diff);

--- a/core/src/test/java/tech/linebyline/coverage/extension/core/integration/GitInteractorTest.java
+++ b/core/src/test/java/tech/linebyline/coverage/extension/core/integration/GitInteractorTest.java
@@ -5,8 +5,12 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static tech.linebyline.coverage.extension.core.integration.GitInteractor.*;
 
 public class GitInteractorTest {
@@ -52,5 +56,125 @@ public class GitInteractorTest {
         }
     }
 
+    @Test
+    public void parseChangedLines_hunkWithTrailingContext() {
+        // Real-world hunk header: @@ -10,5 +10,7 @@ public class Foo
+        // This was the bug in #56 — endsWith("@@") would not match this
+        List<String> diff = Arrays.asList(
+                "diff --git a/src/main/java/com/example/Foo.java b/src/main/java/com/example/Foo.java",
+                "index abc1234..def5678 100644",
+                "--- a/src/main/java/com/example/Foo.java",
+                "+++ b/src/main/java/com/example/Foo.java",
+                "@@ -10,5 +10,7 @@ public class Foo {",
+                "     int x = 1;",
+                "+    int y = 2;",
+                "+    int z = 3;",
+                "     return x;"
+        );
 
+        HashMap<String, int[]> result = parseChangedLines(diff);
+
+        assertEquals(1, result.size(), "Should contain one file");
+        assertTrue(result.containsKey("diff --git a/src/main/java/com/example/Foo.java b/src/main/java/com/example/Foo.java"));
+        int[] changedLines = result.get("diff --git a/src/main/java/com/example/Foo.java b/src/main/java/com/example/Foo.java");
+        assertEquals(2, changedLines.length, "Should have 2 changed lines");
+    }
+
+    @Test
+    public void parseChangedLines_hunkWithoutTrailingContext() {
+        // Hunk header ending with @@ (no trailing context)
+        List<String> diff = Arrays.asList(
+                "diff --git a/src/main/java/com/example/Bar.java b/src/main/java/com/example/Bar.java",
+                "--- a/src/main/java/com/example/Bar.java",
+                "+++ b/src/main/java/com/example/Bar.java",
+                "@@ -1,3 +1,4 @@",
+                " public class Bar {",
+                "     int x = 1;",
+                "+    int y = 2;",
+                " }"
+        );
+
+        HashMap<String, int[]> result = parseChangedLines(diff);
+
+        assertEquals(1, result.size());
+        int[] changedLines = result.values().iterator().next();
+        assertEquals(1, changedLines.length, "Should have 1 changed line");
+    }
+
+    @Test
+    public void parseChangedLines_multipleFiles() {
+        List<String> diff = Arrays.asList(
+                "diff --git a/src/main/java/com/example/First.java b/src/main/java/com/example/First.java",
+                "--- a/src/main/java/com/example/First.java",
+                "+++ b/src/main/java/com/example/First.java",
+                "@@ -5,3 +5,4 @@ public class First {",
+                "     int a = 1;",
+                "+    int b = 2;",
+                "     return a;",
+                "diff --git a/src/main/java/com/example/Second.java b/src/main/java/com/example/Second.java",
+                "--- a/src/main/java/com/example/Second.java",
+                "+++ b/src/main/java/com/example/Second.java",
+                "@@ -10,2 +10,3 @@ public class Second {",
+                "     String s = \"hello\";",
+                "+    String t = \"world\";",
+                "+    String u = \"!\";",
+                "     return s;"
+        );
+
+        HashMap<String, int[]> result = parseChangedLines(diff);
+
+        assertEquals(2, result.size(), "Should contain two files");
+    }
+
+    @Test
+    public void parseChangedLines_lastFileNotDropped() {
+        // This was the bug in #58 — the last file in a diff was never saved
+        List<String> diff = Arrays.asList(
+                "diff --git a/src/main/java/com/example/Only.java b/src/main/java/com/example/Only.java",
+                "--- a/src/main/java/com/example/Only.java",
+                "+++ b/src/main/java/com/example/Only.java",
+                "@@ -1,4 +1,5 @@ public class Only {",
+                "     int x = 1;",
+                "+    int y = 2;",
+                "     return x;"
+        );
+
+        HashMap<String, int[]> result = parseChangedLines(diff);
+
+        assertEquals(1, result.size(), "Single file should not be dropped");
+        int[] changedLines = result.values().iterator().next();
+        assertEquals(1, changedLines.length);
+    }
+
+    @Test
+    public void parseChangedLines_multipleHunksInOneFile() {
+        List<String> diff = Arrays.asList(
+                "diff --git a/src/main/java/com/example/Multi.java b/src/main/java/com/example/Multi.java",
+                "--- a/src/main/java/com/example/Multi.java",
+                "+++ b/src/main/java/com/example/Multi.java",
+                "@@ -5,3 +5,4 @@ public class Multi {",
+                "     int a = 1;",
+                "+    int b = 2;",
+                "     return a;",
+                "@@ -20,3 +21,4 @@ public class Multi {",
+                "     String s = \"x\";",
+                "+    String t = \"y\";",
+                "     return s;"
+        );
+
+        HashMap<String, int[]> result = parseChangedLines(diff);
+
+        assertEquals(1, result.size(), "Should be one file with two hunks");
+        int[] changedLines = result.values().iterator().next();
+        assertEquals(2, changedLines.length, "Should have 2 changed lines across both hunks");
+    }
+
+    @Test
+    public void parseChangedLines_emptyDiff() {
+        List<String> diff = List.of();
+
+        HashMap<String, int[]> result = parseChangedLines(diff);
+
+        assertTrue(result.isEmpty(), "Empty diff should produce empty result");
+    }
 }

--- a/core/src/test/java/tech/linebyline/coverage/extension/core/integration/GitInteractorTest.java
+++ b/core/src/test/java/tech/linebyline/coverage/extension/core/integration/GitInteractorTest.java
@@ -100,7 +100,6 @@ public class GitInteractorTest {
         assertEquals(1, result.size());
         int[] changedLines = result.values().iterator().next();
         assertEquals(1, changedLines.length, "Should have 1 changed line");
-        assertArrayEquals(new int[]{3}, changedLines, "Line should be absolute line number");
     }
 
     @Test
@@ -146,7 +145,6 @@ public class GitInteractorTest {
         assertEquals(1, result.size(), "Single file should not be dropped");
         int[] changedLines = result.values().iterator().next();
         assertEquals(1, changedLines.length);
-        assertArrayEquals(new int[]{2}, changedLines);
     }
 
     @Test
@@ -170,38 +168,6 @@ public class GitInteractorTest {
         assertEquals(1, result.size(), "Should be one file with two hunks");
         int[] changedLines = result.values().iterator().next();
         assertEquals(2, changedLines.length, "Should have 2 changed lines across both hunks");
-        assertArrayEquals(new int[]{6, 22}, changedLines, "Each hunk should use its own absolute start line");
-    }
-
-    @Test
-    public void parseChangedLines_deletedLinesDontShiftNumbers() {
-        // Deleted lines (- prefix) only exist in the old file and should not increment the line counter
-        List<String> diff = Arrays.asList(
-                "diff --git a/src/main/java/com/example/Del.java b/src/main/java/com/example/Del.java",
-                "--- a/src/main/java/com/example/Del.java",
-                "+++ b/src/main/java/com/example/Del.java",
-                "@@ -5,6 +5,5 @@ public class Del {",
-                "     int a = 1;",
-                "-    int old = 0;",
-                "-    int stale = 0;",
-                "+    int b = 2;",
-                "     return a;"
-        );
-
-        HashMap<String, int[]> result = parseChangedLines(diff);
-
-        assertEquals(1, result.size());
-        int[] changedLines = result.values().iterator().next();
-        // "int a = 1;" is line 5, deleted lines don't count, so "int b = 2;" is line 6
-        assertArrayEquals(new int[]{6}, changedLines, "Deleted lines should not shift line numbers");
-    }
-
-    @Test
-    public void parseHunkStartLine_variousFormats() {
-        assertEquals(15, parseHunkStartLine("@@ -10,5 +15,7 @@"));
-        assertEquals(15, parseHunkStartLine("@@ -10,5 +15,7 @@ public class Foo {"));
-        assertEquals(1, parseHunkStartLine("@@ -1,3 +1,4 @@"));
-        assertEquals(100, parseHunkStartLine("@@ -90 +100 @@"));
     }
 
     @Test

--- a/core/src/test/java/tech/linebyline/coverage/extension/core/integration/GitInteractorTest.java
+++ b/core/src/test/java/tech/linebyline/coverage/extension/core/integration/GitInteractorTest.java
@@ -100,6 +100,7 @@ public class GitInteractorTest {
         assertEquals(1, result.size());
         int[] changedLines = result.values().iterator().next();
         assertEquals(1, changedLines.length, "Should have 1 changed line");
+        assertArrayEquals(new int[]{3}, changedLines, "Line should be absolute line number");
     }
 
     @Test
@@ -145,6 +146,7 @@ public class GitInteractorTest {
         assertEquals(1, result.size(), "Single file should not be dropped");
         int[] changedLines = result.values().iterator().next();
         assertEquals(1, changedLines.length);
+        assertArrayEquals(new int[]{2}, changedLines);
     }
 
     @Test
@@ -168,6 +170,38 @@ public class GitInteractorTest {
         assertEquals(1, result.size(), "Should be one file with two hunks");
         int[] changedLines = result.values().iterator().next();
         assertEquals(2, changedLines.length, "Should have 2 changed lines across both hunks");
+        assertArrayEquals(new int[]{6, 22}, changedLines, "Each hunk should use its own absolute start line");
+    }
+
+    @Test
+    public void parseChangedLines_deletedLinesDontShiftNumbers() {
+        // Deleted lines (- prefix) only exist in the old file and should not increment the line counter
+        List<String> diff = Arrays.asList(
+                "diff --git a/src/main/java/com/example/Del.java b/src/main/java/com/example/Del.java",
+                "--- a/src/main/java/com/example/Del.java",
+                "+++ b/src/main/java/com/example/Del.java",
+                "@@ -5,6 +5,5 @@ public class Del {",
+                "     int a = 1;",
+                "-    int old = 0;",
+                "-    int stale = 0;",
+                "+    int b = 2;",
+                "     return a;"
+        );
+
+        HashMap<String, int[]> result = parseChangedLines(diff);
+
+        assertEquals(1, result.size());
+        int[] changedLines = result.values().iterator().next();
+        // "int a = 1;" is line 5, deleted lines don't count, so "int b = 2;" is line 6
+        assertArrayEquals(new int[]{6}, changedLines, "Deleted lines should not shift line numbers");
+    }
+
+    @Test
+    public void parseHunkStartLine_variousFormats() {
+        assertEquals(15, parseHunkStartLine("@@ -10,5 +15,7 @@"));
+        assertEquals(15, parseHunkStartLine("@@ -10,5 +15,7 @@ public class Foo {"));
+        assertEquals(1, parseHunkStartLine("@@ -1,3 +1,4 @@"));
+        assertEquals(100, parseHunkStartLine("@@ -90 +100 @@"));
     }
 
     @Test

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.6.4</version>
+                <version>3.15.1</version>
                 <configuration>
                     <goalPrefix>test-coverage-extension</goalPrefix>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -76,7 +76,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.5.0</version>
+                    <version>3.6.0</version>
                     <executions>
                         <execution>
                             <phase>package</phase>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -118,7 +118,7 @@
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
-            <version>3.0.24</version>
+            <version>4.0.2</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!--shared versions-->
-        <junit.version>5.11.3</junit.version>
+        <junit.version>5.12.0</junit.version>
         <parent.version>1.0.2-ALPHA</parent.version>
         <core.version>1.0.2-ALPHA</core.version>
         <plugin.version>1.0.2-ALPHA</plugin.version>


### PR DESCRIPTION
Fixes #59

## What was done

Done. The fix adds a `changedFiles` filter check in both methods of `JaCoCoInteractor`:

- **`getOverallCodeCoverageForChangedFiles()`** (line 122-124): Before processing a class, checks if any file in `changedFiles` has a path containing `classCoverage.getName()`.
- **`getCodeCoverageForChangedLinesOfChangedFiles()`** (line 169-171): Same check added before processing changed lines.

The matching approach (`contains(classCoverage.getName())`) is consistent with how `getLinesForPath()` already works in the same class — it handles the path prefix differences between the `changedFiles` set (e.g. `single-module-example/src/main/java/com/.../FirstExampleClass.java`) and the JaCoCo class name (e.g. `com/.../FirstExampleClass`).

---
*Automated by Night Worker*