### PR TITLE
Fix/remove snapshot versions

### DIFF
--- a/.github/actions/check-no-snapshots/action.yml
+++ b/.github/actions/check-no-snapshots/action.yml
@@ -1,0 +1,13 @@
+name: 'Check no SNAPSHOT versions'
+description: 'Fails if any pom.xml contains a SNAPSHOT version'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Check for SNAPSHOT versions
+      shell: bash
+      run: |
+        if grep -r "SNAPSHOT" --include="pom.xml" .; then
+          echo "::error::SNAPSHOT versions found in pom.xml files. Release builds must not contain SNAPSHOT versions."
+          exit 1
+        fi

--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -33,5 +33,7 @@ jobs:
         with:
           gpg_private_key: ${{ secrets.GPG_SIGN_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Check no SNAPSHOT versions
+        uses: ./.github/actions/check-no-snapshots
       - name: Deploy
         run: mvn deploy

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -22,5 +22,7 @@ jobs:
         with:
           gpg_private_key: ${{ secrets.GPG_SIGN_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Check no SNAPSHOT versions
+        uses: ./.github/actions/check-no-snapshots
       - name: Run the Maven verify phase
         run: mvn --batch-mode --update-snapshots verify


### PR DESCRIPTION
Having snapshot dependencies causes deployment failure. Maven central doesn't allow it.

Adding this check to ensure we don't use dependencies with snapshot