### PR TITLE
fix: Deleted/renamed files not handled in getOverviewOfChangedFiles() (#60)

### DIFF
--- a/core/src/main/java/tech/linebyline/coverage/extension/core/integration/GitInteractor.java
+++ b/core/src/main/java/tech/linebyline/coverage/extension/core/integration/GitInteractor.java
@@ -36,8 +36,7 @@ public class GitInteractor {
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
                 String line;
                 while ((line = reader.readLine()) != null) {
-                    // Add each changed file (line) to the list
-                    changedFiles.add(new File(line.split("\t")[1]));
+                    changedFiles.addAll(parseNameStatusLine(line));
                 }
             }
 
@@ -62,6 +61,35 @@ public class GitInteractor {
         }
 
         return changedFiles;
+    }
+
+    /**
+     * Parses a single line of {@code git diff --name-status} output into a set of {@link File}s.
+     * <ul>
+     *   <li>Deleted files (status {@code D}) are skipped — they no longer exist on the current branch.</li>
+     *   <li>Renamed files (status {@code R<score>}, e.g. {@code R100}) use {@code parts[2]} (the new name).</li>
+     *   <li>Only {@code .java} files are included — other file types have no JaCoCo coverage data.</li>
+     * </ul>
+     */
+    protected static Set<File> parseNameStatusLine(String line) {
+        Set<File> result = new HashSet<>();
+        String[] parts = line.split("\t");
+        String status = parts[0];
+
+        // Skip deleted files — they no longer exist in the working tree
+        if (status.startsWith("D")) {
+            return result;
+        }
+
+        // For renames (R followed by similarity score, e.g. R100), use the new filename (parts[2])
+        String filePath = status.startsWith("R") ? parts[2] : parts[1];
+
+        // Only include Java source files — non-Java files have no JaCoCo coverage data
+        if (filePath.endsWith(".java")) {
+            result.add(new File(filePath));
+        }
+
+        return result;
     }
 
     /**

--- a/core/src/test/java/tech/linebyline/coverage/extension/core/integration/GitInteractorTest.java
+++ b/core/src/test/java/tech/linebyline/coverage/extension/core/integration/GitInteractorTest.java
@@ -218,4 +218,49 @@ public class GitInteractorTest {
 
         assertTrue(result.isEmpty(), "Empty diff should produce empty result");
     }
+
+    @Test
+    public void parseNameStatusLineModifiedJavaFileTest() {
+        Set<File> result = parseNameStatusLine("M\tsrc/main/java/com/example/Foo.java");
+        assertEquals(1, result.size());
+        assertEquals(new File("src/main/java/com/example/Foo.java"), result.iterator().next());
+    }
+
+    @Test
+    public void parseNameStatusLineAddedJavaFileTest() {
+        Set<File> result = parseNameStatusLine("A\tsrc/main/java/com/example/Bar.java");
+        assertEquals(1, result.size());
+        assertEquals(new File("src/main/java/com/example/Bar.java"), result.iterator().next());
+    }
+
+    @Test
+    public void parseNameStatusLineDeletedJavaFileIsSkippedTest() {
+        Set<File> result = parseNameStatusLine("D\tsrc/main/java/com/example/Deleted.java");
+        assertTrue(result.isEmpty(), "Deleted files should be excluded");
+    }
+
+    @Test
+    public void parseNameStatusLineRenamedJavaFileUsesNewNameTest() {
+        Set<File> result = parseNameStatusLine("R100\told/path/OldName.java\tnew/path/NewName.java");
+        assertEquals(1, result.size());
+        assertEquals(new File("new/path/NewName.java"), result.iterator().next());
+    }
+
+    @Test
+    public void parseNameStatusLineNonJavaFileIsSkippedTest() {
+        Set<File> xmlResult = parseNameStatusLine("M\tsrc/main/resources/application.xml");
+        assertTrue(xmlResult.isEmpty(), "XML files should be excluded");
+
+        Set<File> mdResult = parseNameStatusLine("A\tREADME.md");
+        assertTrue(mdResult.isEmpty(), "Markdown files should be excluded");
+
+        Set<File> propsResult = parseNameStatusLine("M\tsrc/main/resources/app.properties");
+        assertTrue(propsResult.isEmpty(), "Properties files should be excluded");
+    }
+
+    @Test
+    public void parseNameStatusLineRenamedNonJavaFileIsSkippedTest() {
+        Set<File> result = parseNameStatusLine("R95\told/README.md\tnew/README.md");
+        assertTrue(result.isEmpty(), "Renamed non-Java files should be excluded");
+    }
 }


### PR DESCRIPTION
Fixes #60

## What was done

Done. Here's a summary of the changes:

**`GitInteractor.java`** — extracted a new `protected static parseNameStatusLine(String line)` method that:
1. **Skips deleted files** — status starting with `D` returns an empty set
2. **Uses the new name for renames** — status starting with `R` (e.g. `R100`) reads `parts[2]` instead of `parts[1]`
3. **Filters to `.java` files only** — non-Java files are silently ignored

`getOverviewOfChangedFiles()` now delegates to this helper via `changedFiles.addAll(parseNameStatusLine(line))`.

**`GitInteractorTest.java`** — added 6 new unit tests covering:
- Modified Java file included
- Added Java file included
- Deleted Java file excluded
- Renamed file uses new name
- Non-Java files (xml, md, properties) excluded
- Renamed non-Java file excluded

---
*Automated by Night Worker*